### PR TITLE
Chromeのデフォルトの「戻る」操作をした際の不具合修正

### DIFF
--- a/static/home.js
+++ b/static/home.js
@@ -5,6 +5,14 @@
 // アラートが既に表示されたかどうかを示すフラグ
 let alertShown = false;
 
+// Chromeのデフォルトの戻る操作がされたとき、選択されているファイルのプレビュー表示を行う
+window.onload = function() {
+  var fileInput = document.getElementById('dragDropArea');
+  var selectedFile = fileInput.files;
+  // 選択されたファイルのプレビュー表示を行うため、showPreview関数の呼び出し
+  showPreview(selectedFile);
+}
+
 // ドラッグ＆ドロップの際に枠線の見た目を変更
 function handleDragEnter() {
   document.getElementById('dragDropArea').style.border = '6px dashed #87CEEB';


### PR DESCRIPTION
概要(どんな作業をしたか)
　・puzzle.htmlにいる状態でChromeの「戻る」操作をした場合、ファイルは選択されている状態であるのに、プレビューが表示されない不具合と、「パズルスタート」ボタンを押した際に「ファイルが選択されていません」というメッセージが表示されてしまう不具合を修正しました。
 

変更点(どんな変更をしたか)
　・Chromeで「戻る」操作をしてhome.htmlが再度読み込まれた際、この読み込みを検知してプレビュー処理を行う機能を追加（home.js）
 

その他コメント
　・今回の変更の影響で新たなエラーが起きてしまう可能性も考えられるので、一度パズルを遊んで、不具合等がないか確認していただけると嬉しいです。